### PR TITLE
Added a prop-types peer dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "peerDependencies": {
     "react": "15.x.x",
-    "react-dom": "15.x.x"
+    "react-dom": "15.x.x",
+    "prop-types": "15.x.x"
   }
 }

--- a/src/EntypoIcon/index.js
+++ b/src/EntypoIcon/index.js
@@ -1,4 +1,5 @@
-import React, {Component, PropTypes} from 'react';
+import React, {Component} from 'react';
+import PropTypes from 'prop-types';
 
 class EntypoIcon extends React.Component {
   constructor(props){


### PR DESCRIPTION
This fixes React 15.5 PropTypes warnings.